### PR TITLE
print the formatter string if present

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,6 +3,8 @@ import logging
    
 def show_dict_fields(prefix, dict1):
     for fld,val in dict1.items():
+                if hasattr(val, '_fmt'):
+                    val = val._fmt
                 print('%s%s=%s' %(prefix, fld,val) )
 def show_log(k,v):
     if not isinstance(v, logging.PlaceHolder):


### PR DESCRIPTION
Hello @mickeyperlstein - thanks for creating this!

I've added a tiny feature to print the formatting string if it is present.  It's working for me, I see output like this:

```
+ [application         ] {logging.Logger} {INFO}
-------------------------
    -filters=[]
    -name=application
    -level=20
    -parent=<RootLogger root (WARNING)>
    -propagate=True
    -handlers=[<StreamHandler <stderr> (NOTSET)>]
    -disabled=False
    -_cache={}
    -manager=<logging.Manager object at 0x1020717f0>
     +++logging.StreamHandler {NOTSET}
    -filters=[]
    -_name=None
    -level=0
    -formatter=[%(asctime)s] %(levelname)s in %(module)s: %(message)s
    -lock=<unlocked _thread.RLock object owner=0 count=0 at 0x102583c60>
    -stream=<_io.TextIOWrapper name='<stderr>' mode='w' encoding='utf-8'>
```